### PR TITLE
load doorkeeper

### DIFF
--- a/lib/doorkeeper-mongodb.rb
+++ b/lib/doorkeeper-mongodb.rb
@@ -1,5 +1,7 @@
 require 'doorkeeper-mongodb/version'
 
+require 'doorkeeper'
+
 require 'doorkeeper/orm/mongoid2'
 require 'doorkeeper/orm/mongoid3'
 require 'doorkeeper/orm/mongoid4'


### PR DESCRIPTION
load doorkeeper first, or will raise `undefined method `configure' for Doorkeeper:Module (NoMethodError)`

because in dev env, `doorkeeper` is added in `Gemfile`, so bundler will help to require it, but `Readme` said just add `doorkeeper-mongodb` into `Gemfile` so bundler will not automatic require `doorkeeper`