### PR TITLE
Cleanup

### DIFF
--- a/gemfiles/Gemfile.common.rb
+++ b/gemfiles/Gemfile.common.rb
@@ -3,6 +3,5 @@ ENV['rails'] ||= '4.2.0'
 source 'https://rubygems.org'
 
 gem 'rails', "~> #{ENV['rails']}"
-gem 'doorkeeper'
 
 gemspec path: '../'

--- a/lib/doorkeeper/orm/mongoid2/access_grant.rb
+++ b/lib/doorkeeper/orm/mongoid2/access_grant.rb
@@ -11,7 +11,6 @@ module Doorkeeper
     self.store_in :oauth_access_grants
 
     field :resource_owner_id, type: Integer
-    field :application_id, type: BSON::ObjectId
     field :token, type: String
     field :expires_in, type: Integer
     field :redirect_uri, type: String

--- a/lib/doorkeeper/orm/mongoid2/access_token.rb
+++ b/lib/doorkeeper/orm/mongoid2/access_token.rb
@@ -11,7 +11,6 @@ module Doorkeeper
     self.store_in :oauth_access_tokens
 
     field :resource_owner_id, type: Integer
-    field :application_id, type: BSON::ObjectId
     field :token, type: String
     field :refresh_token, type: String
     field :expires_in, type: Integer

--- a/lib/doorkeeper/orm/mongoid3/access_grant.rb
+++ b/lib/doorkeeper/orm/mongoid3/access_grant.rb
@@ -11,7 +11,6 @@ module Doorkeeper
     self.store_in collection: :oauth_access_grants
 
     field :resource_owner_id, type: Moped::BSON::ObjectId
-    field :application_id, type: Moped::BSON::ObjectId
     field :token, type: String
     field :expires_in, type: Integer
     field :redirect_uri, type: String

--- a/lib/doorkeeper/orm/mongoid3/access_token.rb
+++ b/lib/doorkeeper/orm/mongoid3/access_token.rb
@@ -11,7 +11,6 @@ module Doorkeeper
     self.store_in collection: :oauth_access_tokens
 
     field :resource_owner_id, type: Moped::BSON::ObjectId
-    field :application_id, type: Moped::BSON::ObjectId
     field :token, type: String
     field :refresh_token, type: String
     field :expires_in, type: Integer

--- a/lib/doorkeeper/orm/mongoid4/access_grant.rb
+++ b/lib/doorkeeper/orm/mongoid4/access_grant.rb
@@ -11,7 +11,6 @@ module Doorkeeper
     self.store_in collection: :oauth_access_grants
 
     field :resource_owner_id, type: BSON::ObjectId
-    field :application_id, type: BSON::ObjectId
     field :token, type: String
     field :expires_in, type: Integer
     field :redirect_uri, type: String

--- a/lib/doorkeeper/orm/mongoid4/access_token.rb
+++ b/lib/doorkeeper/orm/mongoid4/access_token.rb
@@ -11,7 +11,6 @@ module Doorkeeper
     self.store_in collection: :oauth_access_tokens
 
     field :resource_owner_id, type: BSON::ObjectId
-    field :application_id, type: BSON::ObjectId
     field :token, type: String
     field :refresh_token, type: String
     field :expires_in, type: Integer


### PR DESCRIPTION
- `doorkeeper` already as a dependency in `.gemspec`
- resolve `WARN -- : Overwriting existing field application_id in class Doorkeeper::AccessToken.`
- resolve `Overwriting existing field application_id in class Doorkeeper::AccessGrant.`