### PR TITLE
Allow to pass empty values to scopes in Mongoid 2,3,4

### DIFF
--- a/lib/doorkeeper/orm/mongoid2/concerns/scopes.rb
+++ b/lib/doorkeeper/orm/mongoid2/concerns/scopes.rb
@@ -21,7 +21,7 @@ module Doorkeeper
           end
 
           def scopes=(value)
-            write_attribute :scopes, value if value.present?
+            write_attribute :scopes, value
           end
         end
       end

--- a/lib/doorkeeper/orm/mongoid3/concerns/scopes.rb
+++ b/lib/doorkeeper/orm/mongoid3/concerns/scopes.rb
@@ -21,7 +21,7 @@ module Doorkeeper
           end
 
           def scopes=(value)
-            write_attribute :scopes, value if value.present?
+            write_attribute :scopes, value
           end
         end
       end

--- a/lib/doorkeeper/orm/mongoid4/concerns/scopes.rb
+++ b/lib/doorkeeper/orm/mongoid4/concerns/scopes.rb
@@ -9,7 +9,7 @@ module Doorkeeper
         end
 
         def scopes=(value)
-          write_attribute :scopes, value if value.present?
+          write_attribute :scopes, value
         end
       end
     end


### PR DESCRIPTION
Looks like the scopes concerns does not allow empty values to be passed by. Once selected application scopes (for example) is not possible to remove all of them.
Passing nil or an empty string is ignored.