### PR TITLE
El/pkce gem pr

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,8 @@ en:
               relative_uri: 'must be an absolute URI.'
               secured_uri: 'must be an HTTPS/SSL URI.'
               forbidden_uri: 'is forbidden by the server.'
+            scopes:
+              not_match_configured: "doesn't match configured on the server."
 
   mongoid:
     <<: *orm

--- a/doorkeeper-mongodb.gemspec
+++ b/doorkeeper-mongodb.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.files      = Dir['lib/**/*', 'config/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
   gem.test_files = Dir['spec/**/*']
 
-  gem.add_dependency 'doorkeeper', '>= 4.4', '< 5.0'
+  gem.add_dependency 'doorkeeper', '>= 5.0', '< 6.0'
 
   gem.add_development_dependency 'grape'
   gem.add_development_dependency 'coveralls'

--- a/gemfiles/Gemfile.common.rb
+++ b/gemfiles/Gemfile.common.rb
@@ -1,5 +1,5 @@
 ENV['RAILS'] ||= '4.2'
-ENV['DOORKEEPER'] ||= '4.4'
+ENV['DOORKEEPER'] ||= '5.0'
 
 source 'https://rubygems.org'
 

--- a/lib/doorkeeper-mongodb.rb
+++ b/lib/doorkeeper-mongodb.rb
@@ -12,6 +12,7 @@ require 'doorkeeper-mongodb/mixins/mongo_mapper/base_mixin'
 require 'doorkeeper-mongodb/mixins/mongo_mapper/access_grant_mixin'
 require 'doorkeeper-mongodb/mixins/mongo_mapper/access_token_mixin'
 require 'doorkeeper-mongodb/mixins/mongo_mapper/application_mixin'
+require 'doorkeeper-mongodb/mixins/mongo_mapper/stale_records_cleaner_mixin'
 
 require 'doorkeeper/orm/mongo_mapper'
 
@@ -19,6 +20,7 @@ require 'doorkeeper-mongodb/mixins/mongoid/base_mixin'
 require 'doorkeeper-mongodb/mixins/mongoid/access_grant_mixin'
 require 'doorkeeper-mongodb/mixins/mongoid/access_token_mixin'
 require 'doorkeeper-mongodb/mixins/mongoid/application_mixin'
+require 'doorkeeper-mongodb/mixins/mongoid/stale_records_cleaner_mixin'
 
 # Maybe we need to squash this into one? With backward compatibility
 require 'doorkeeper/orm/mongoid4'
@@ -29,7 +31,7 @@ require 'doorkeeper/orm/mongoid7'
 module DoorkeeperMongodb
   def load_locales
     locales_dir = File.expand_path('../../config/locales', __FILE__)
-    locales = Dir[File.join(locales_dir, '*.yml')]
+    locales     = Dir[File.join(locales_dir, '*.yml')]
 
     I18n.load_path |= locales
   end

--- a/lib/doorkeeper-mongodb/mixins/mongo_mapper/access_grant_mixin.rb
+++ b/lib/doorkeeper-mongodb/mixins/mongo_mapper/access_grant_mixin.rb
@@ -41,6 +41,68 @@ module DoorkeeperMongodb
           def by_token(token)
             where(token: token.to_s).first
           end
+
+          # Revokes AccessGrant records that have not been revoked and associated
+          # with the specific Application and Resource Owner.
+          #
+          # @param application_id [Integer]
+          #   ID of the Application
+          # @param resource_owner [ActiveRecord::Base]
+          #   instance of the Resource Owner model
+          #
+          def revoke_all_for(application_id, resource_owner, clock = Time)
+            where(application_id:    application_id,
+                  resource_owner_id: resource_owner.id,
+                  revoked_at:        nil)
+                .update_all(revoked_at: clock.now.utc)
+          end
+
+          # Implements PKCE code_challenge encoding without base64 padding as described in the spec.
+          # https://tools.ietf.org/html/rfc7636#appendix-A
+          #   Appendix A.  Notes on Implementing Base64url Encoding without Padding
+          #
+          #   This appendix describes how to implement a base64url-encoding
+          #   function without padding, based upon the standard base64-encoding
+          #   function that uses padding.
+          #
+          #       To be concrete, example C# code implementing these functions is shown
+          #   below.  Similar code could be used in other languages.
+          #
+          #   static string base64urlencode(byte [] arg)
+          #   {
+          #       string s = Convert.ToBase64String(arg); // Regular base64 encoder
+          #       s = s.Split('=')[0]; // Remove any trailing '='s
+          #       s = s.Replace('+', '-'); // 62nd char of encoding
+          #       s = s.Replace('/', '_'); // 63rd char of encoding
+          #       return s;
+          #   }
+          #
+          #   An example correspondence between unencoded and encoded values
+          #   follows.  The octet sequence below encodes into the string below,
+          #   which when decoded, reproduces the octet sequence.
+          #
+          #   3 236 255 224 193
+          #
+          #   A-z_4ME
+          #
+          # https://ruby-doc.org/stdlib-2.1.3/libdoc/base64/rdoc/Base64.html#method-i-urlsafe_encode64
+          #
+          # urlsafe_encode64(bin)
+          # Returns the Base64-encoded version of bin. This method complies with
+          # "Base 64 Encoding with URL and Filename Safe Alphabet" in RFC 4648.
+          # The alphabet uses '-' instead of '+' and '_' instead of '/'.
+
+          # @param code_verifier [#to_s] a one time use value (any object that responds to `#to_s`)
+          #
+          # @return [#to_s] An encoded code challenge based on the provided verifier suitable for PKCE validation
+          def generate_code_challenge(code_verifier)
+            padded_result = Base64.urlsafe_encode64(Digest::SHA256.digest(code_verifier))
+            padded_result.split('=')[0] # Remove any trailing '='
+          end
+
+          def pkce_supported?
+            new.pkce_supported?
+          end
         end
 
         private

--- a/lib/doorkeeper-mongodb/mixins/mongo_mapper/application_mixin.rb
+++ b/lib/doorkeeper-mongodb/mixins/mongo_mapper/application_mixin.rb
@@ -17,16 +17,17 @@ module DoorkeeperMongodb
           validates :redirect_uri, redirect_uri: true
           validates :confidential, inclusion: { in: [true, false] }
 
-          before_validation :generate_uid, :generate_secret, on: :create
+          validate :scopes_match_configured, if: :enforce_scopes?
 
-          def redirect_uri=(uris)
-            super(uris.is_a?(Array) ? uris.join("\n") : uris)
-          end
+          before_validation :generate_uid, :generate_secret, on: :create
         end
 
         module ClassMethods
           # Returns an instance of the Doorkeeper::Application with
           # specific UID and secret.
+          #
+          # Public/Non-confidential applications will only find by uid if secret is
+          # blank.
           #
           # @param uid [#to_s] UID (any object that responds to `#to_s`)
           # @param secret [#to_s] secret (any object that responds to `#to_s`)
@@ -37,7 +38,7 @@ module DoorkeeperMongodb
           def by_uid_and_secret(uid, secret)
             app = by_uid(uid)
             return unless app
-            return app if secret.blank? && !app.confidential
+            return app if secret.blank? && !app.confidential?
             return unless app.secret == secret
             app
           end
@@ -53,34 +54,28 @@ module DoorkeeperMongodb
             where(uid: uid.to_s).first
           end
 
-          def supports_confidentiality?
-            if respond_to?(:column_names)
-              column_names.include?("confidential")
-            else
-              fields.include?("confidential")
-            end
+          # Revokes AccessToken and AccessGrant records that have not been revoked and
+          # associated with the specific Application and Resource Owner.
+          #
+          # @param resource_owner [ActiveRecord::Base]
+          #   instance of the Resource Owner model
+          #
+          def revoke_tokens_and_grants_for(id, resource_owner)
+            Doorkeeper::AccessToken.revoke_all_for(id, resource_owner)
+            Doorkeeper::AccessGrant.revoke_all_for(id, resource_owner)
           end
         end
 
-        # Fallback to existing, default behaviour of assuming all apps to be
-        # confidential if the migration hasn't been run
-        def confidential
-          return super if self.class.supports_confidentiality?
-
-          ActiveSupport::Deprecation.warn 'You are susceptible to security bug ' \
-            'CVE-2018-1000211. Please follow instructions outlined in ' \
-            'Doorkeeper::CVE_2018_1000211_WARNING'
-
-          true
+        # Set an application's valid redirect URIs.
+        #
+        # @param uris [String, Array] Newline-separated string or array the URI(s)
+        #
+        # @return [String] The redirect URI(s) seperated by newlines.
+        def redirect_uri=(uris)
+          super(uris.is_a?(Array) ? uris.join("\n") : uris)
         end
-
-        alias_method :confidential?, :confidential
 
         private
-
-        def has_scopes?
-          Doorkeeper::Application.keys.keys.include?("scopes")
-        end
 
         def generate_uid
           if uid.blank?
@@ -92,6 +87,17 @@ module DoorkeeperMongodb
           if secret.blank?
             self.secret = UniqueToken.generate
           end
+        end
+
+        def scopes_match_configured
+          if scopes.present? &&
+              !ScopeChecker.valid?(scopes.to_s, Doorkeeper.configuration.scopes)
+            errors.add(:scopes, :not_match_configured)
+          end
+        end
+
+        def enforce_scopes?
+          Doorkeeper.configuration.enforce_configured_scopes?
         end
       end
     end

--- a/lib/doorkeeper-mongodb/mixins/mongo_mapper/base_mixin.rb
+++ b/lib/doorkeeper-mongodb/mixins/mongo_mapper/base_mixin.rb
@@ -9,6 +9,14 @@ module DoorkeeperMongodb
             sort(attribute.to_sym.send(direction.to_sym))
           end
         end
+
+        def as_json(*args)
+          json_response = super
+
+          json_response["id"] = json_response["_id"]
+
+          json_response
+        end
       end
     end
   end

--- a/lib/doorkeeper-mongodb/mixins/mongo_mapper/stale_records_cleaner_mixin.rb
+++ b/lib/doorkeeper-mongodb/mixins/mongo_mapper/stale_records_cleaner_mixin.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module DoorkeeperMongodb
+  module Mixins
+    module MongoMapper
+      module StaleRecordsCleanerMixin
+        def initialize(base_scope)
+          @base_scope = base_scope
+        end
+
+        def clean_revoked
+          @base_scope.where(:revoked_at.ne => nil, :revoked_at.lt => Time.current).delete_all
+        end
+
+        def clean_expired(ttl)
+          @base_scope.where(:created_at.lt => Time.current - ttl).delete_all
+        end
+      end
+    end
+  end
+end

--- a/lib/doorkeeper-mongodb/mixins/mongoid/access_grant_mixin.rb
+++ b/lib/doorkeeper-mongodb/mixins/mongoid/access_grant_mixin.rb
@@ -49,7 +49,69 @@ module DoorkeeperMongodb
           #   if there is no record with such token
           #
           def by_token(token)
-            where(token: token.to_s).find_first
+            where(token: token.to_s).first
+          end
+
+          # Revokes AccessGrant records that have not been revoked and associated
+          # with the specific Application and Resource Owner.
+          #
+          # @param application_id [Integer]
+          #   ID of the Application
+          # @param resource_owner [ActiveRecord::Base]
+          #   instance of the Resource Owner model
+          #
+          def revoke_all_for(application_id, resource_owner, clock = Time)
+            where(application_id:    application_id,
+                  resource_owner_id: resource_owner.id,
+                  revoked_at:        nil)
+                .update_all(revoked_at: clock.now.utc)
+          end
+
+          # Implements PKCE code_challenge encoding without base64 padding as described in the spec.
+          # https://tools.ietf.org/html/rfc7636#appendix-A
+          #   Appendix A.  Notes on Implementing Base64url Encoding without Padding
+          #
+          #   This appendix describes how to implement a base64url-encoding
+          #   function without padding, based upon the standard base64-encoding
+          #   function that uses padding.
+          #
+          #       To be concrete, example C# code implementing these functions is shown
+          #   below.  Similar code could be used in other languages.
+          #
+          #   static string base64urlencode(byte [] arg)
+          #   {
+          #       string s = Convert.ToBase64String(arg); // Regular base64 encoder
+          #       s = s.Split('=')[0]; // Remove any trailing '='s
+          #       s = s.Replace('+', '-'); // 62nd char of encoding
+          #       s = s.Replace('/', '_'); // 63rd char of encoding
+          #       return s;
+          #   }
+          #
+          #   An example correspondence between unencoded and encoded values
+          #   follows.  The octet sequence below encodes into the string below,
+          #   which when decoded, reproduces the octet sequence.
+          #
+          #   3 236 255 224 193
+          #
+          #   A-z_4ME
+          #
+          # https://ruby-doc.org/stdlib-2.1.3/libdoc/base64/rdoc/Base64.html#method-i-urlsafe_encode64
+          #
+          # urlsafe_encode64(bin)
+          # Returns the Base64-encoded version of bin. This method complies with
+          # "Base 64 Encoding with URL and Filename Safe Alphabet" in RFC 4648.
+          # The alphabet uses '-' instead of '+' and '_' instead of '/'.
+
+          # @param code_verifier [#to_s] a one time use value (any object that responds to `#to_s`)
+          #
+          # @return [#to_s] An encoded code challenge based on the provided verifier suitable for PKCE validation
+          def generate_code_challenge(code_verifier)
+            padded_result = Base64.urlsafe_encode64(Digest::SHA256.digest(code_verifier))
+            padded_result.split('=')[0] # Remove any trailing '='
+          end
+
+          def pkce_supported?
+            new.pkce_supported?
           end
         end
 

--- a/lib/doorkeeper-mongodb/mixins/mongoid/access_token_mixin.rb
+++ b/lib/doorkeeper-mongodb/mixins/mongoid/access_token_mixin.rb
@@ -73,14 +73,14 @@ module DoorkeeperMongodb
           # @param resource_owner [ActiveRecord::Base]
           #   instance of the Resource Owner model
           #
-          def revoke_all_for(application_id, resource_owner)
-            where(application_id: application_id,
+          def revoke_all_for(application_id, resource_owner, clock = Time)
+            where(application_id:    application_id,
                   resource_owner_id: resource_owner.id,
-                  revoked_at: nil).
-              each(&:revoke)
+                  revoked_at:        nil).
+                update_all(revoked_at: clock.now.utc)
           end
 
-          # Looking for not expired Access Token with a matching set of scopes
+          # Looking for not revoked Access Token with a matching set of scopes
           # that belongs to specific Application and Resource Owner.
           #
           # @param application [Doorkeeper::Application]
@@ -99,9 +99,10 @@ module DoorkeeperMongodb
                                 else
                                   resource_owner_or_id
                                 end
-            token = last_authorized_token_for(application.try(:id), resource_owner_id)
-            if token && scopes_match?(token.scopes, scopes, application.try(:scopes))
-              token
+
+            tokens = authorized_tokens_for(application.try(:id), resource_owner_id)
+            tokens.detect do |token|
+              scopes_match?(token.scopes, scopes, application.try(:scopes))
             end
           end
 
@@ -110,19 +111,23 @@ module DoorkeeperMongodb
           #
           # @param token_scopes [#to_s]
           #   set of scopes (any object that responds to `#to_s`)
-          # @param param_scopes [String]
+          # @param param_scopes [Doorkeeper::OAuth::Scopes]
           #   scopes from params
-          # @param app_scopes [String]
+          # @param app_scopes [Doorkeeper::OAuth::Scopes]
           #   Application scopes
           #
-          # @return [Boolean] true if all scopes and blank or matches
+          # @return [Boolean] true if the param scopes match the token scopes,
+          #   and all the param scopes are defined in the application (or in the
+          #   server configuration if the application doesn't define any scopes),
           #   and false in other cases
           #
           def scopes_match?(token_scopes, param_scopes, app_scopes)
-            (!token_scopes.present? && !param_scopes.present?) ||
-              Doorkeeper::OAuth::Helpers::ScopeChecker.match?(
-                token_scopes.to_s,
-                param_scopes,
+            return true if token_scopes.empty? && param_scopes.empty?
+
+            (token_scopes.sort == param_scopes.sort) &&
+              Doorkeeper::OAuth::Helpers::ScopeChecker.valid?(
+                param_scopes.to_s,
+                Doorkeeper.configuration.scopes,
                 app_scopes
               )
           end
@@ -147,22 +152,38 @@ module DoorkeeperMongodb
           def find_or_create_for(application, resource_owner_id, scopes, expires_in, use_refresh_token)
             if Doorkeeper.configuration.reuse_access_token
               access_token = matching_token_for(application, resource_owner_id, scopes)
-              if access_token && !access_token.expired?
-                return access_token
-              end
+
+              return access_token if access_token && !access_token.expired?
             end
 
             create!(
-              application_id: application.try(:id),
+              application_id:    application.try(:id),
               resource_owner_id: resource_owner_id,
-              scopes: scopes.to_s,
-              expires_in: expires_in,
+              scopes:            scopes.to_s,
+              expires_in:        expires_in,
               use_refresh_token: use_refresh_token
             )
           end
 
-          # Looking for not revoked Access Token record that belongs to specific
+          # Looking for not revoked Access Token records that belongs to specific
           # Application and Resource Owner.
+          #
+          # @param application_id [Integer]
+          #   ID of the Application model instance
+          # @param resource_owner_id [Integer]
+          #   ID of the Resource Owner model instance
+          #
+          # @return [Doorkeeper::AccessToken] array of matching AccessToken objects
+          #
+          def authorized_tokens_for(application_id, resource_owner_id)
+            send(order_method, created_at_desc).
+                where(application_id:    application_id,
+                      resource_owner_id: resource_owner_id,
+                      revoked_at:        nil)
+          end
+
+          # Convenience method for backwards-compatibility, return the last
+          # matching token for the given Application and Resource Owner.
           #
           # @param application_id [Integer]
           #   ID of the Application model instance
@@ -173,10 +194,7 @@ module DoorkeeperMongodb
           #   nil if nothing was found
           #
           def last_authorized_token_for(application_id, resource_owner_id)
-            send(order_method, created_at_desc).
-              where(application_id: application_id,
-                    resource_owner_id: resource_owner_id,
-                    revoked_at: nil).first
+            authorized_tokens_for(application_id, resource_owner_id).first
           end
         end
 
@@ -200,10 +218,10 @@ module DoorkeeperMongodb
         def as_json(_options = {})
           {
             resource_owner_id: resource_owner_id,
-            scope: scopes,
-            expires_in: expires_in_seconds,
-            application: {uid: application.try(:uid)},
-            created_at: created_at.to_i
+            scope:             scopes,
+            expires_in:        expires_in_seconds,
+            application:       { uid: application.try(:uid) },
+            created_at:        created_at.to_i
           }
         end
 
@@ -237,7 +255,7 @@ module DoorkeeperMongodb
         # @return [String] refresh token value
         #
         def generate_refresh_token
-          write_attribute :refresh_token, UniqueToken.generate
+          self.refresh_token = UniqueToken.generate
         end
 
         # Generates and sets the token value with the
@@ -253,23 +271,22 @@ module DoorkeeperMongodb
         def generate_token
           self.created_at ||= Time.now.utc
 
-          generator = token_generator
-          unless generator.respond_to?(:generate)
-            raise Doorkeeper::Errors::UnableToGenerateToken, "#{generator} does not respond to `.generate`."
-          end
-
-          self.token = generator.generate(
+          self.token = token_generator.generate(
             resource_owner_id: resource_owner_id,
-            scopes: scopes,
-            application: application,
-            expires_in: expires_in,
-            created_at: created_at
+            scopes:            scopes,
+            application:       application,
+            expires_in:        expires_in,
+            created_at:        created_at
           )
         end
 
         def token_generator
           generator_name = Doorkeeper.configuration.access_token_generator
-          generator_name.constantize
+          generator = generator_name.constantize
+
+          return generator if generator.respond_to?(:generate)
+
+          raise Doorkeeper::Errors::UnableToGenerateToken, "#{generator} does not respond to `.generate`."
         rescue NameError
           raise Doorkeeper::Errors::TokenGeneratorNotFound, "#{generator_name} not found"
         end

--- a/lib/doorkeeper-mongodb/mixins/mongoid/base_mixin.rb
+++ b/lib/doorkeeper-mongodb/mixins/mongoid/base_mixin.rb
@@ -9,6 +9,14 @@ module DoorkeeperMongodb
             order_by(attribute => direction.to_sym)
           end
         end
+
+        def as_json(*args)
+          json_response = super
+
+          json_response["id"] = json_response["_id"]
+
+          json_response
+        end
       end
     end
   end

--- a/lib/doorkeeper-mongodb/mixins/mongoid/stale_records_cleaner_mixin.rb
+++ b/lib/doorkeeper-mongodb/mixins/mongoid/stale_records_cleaner_mixin.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module DoorkeeperMongodb
+  module Mixins
+    module Mongoid
+      module StaleRecordsCleanerMixin
+        def initialize(base_scope)
+          @base_scope = base_scope
+        end
+
+        def clean_revoked
+          @base_scope.where(:revoked_at.ne => nil, :revoked_at.lt => Time.current).delete_all
+        end
+
+        def clean_expired(ttl)
+          @base_scope.where(:created_at.lt => Time.current - ttl).delete_all
+        end
+      end
+    end
+  end
+end

--- a/lib/doorkeeper-mongodb/version.rb
+++ b/lib/doorkeeper-mongodb/version.rb
@@ -5,8 +5,8 @@ module DoorkeeperMongodb
 
   module VERSION
     # Semver
-    MAJOR = 4
-    MINOR = 2
+    MAJOR = 5
+    MINOR = 0
     TINY = 0
 
     # Full version number

--- a/lib/doorkeeper/orm/mongo_mapper.rb
+++ b/lib/doorkeeper/orm/mongo_mapper.rb
@@ -10,6 +10,7 @@ module Doorkeeper
           require 'doorkeeper/orm/mongo_mapper/access_grant'
           require 'doorkeeper/orm/mongo_mapper/access_token'
           require 'doorkeeper/orm/mongo_mapper/application'
+          require 'doorkeeper/orm/mongo_mapper/stale_records_cleaner'
         end
       end
 

--- a/lib/doorkeeper/orm/mongo_mapper/stale_records_cleaner.rb
+++ b/lib/doorkeeper/orm/mongo_mapper/stale_records_cleaner.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module Orm
+    module MongoMapper
+      class StaleRecordsCleaner
+        include DoorkeeperMongodb::Mixins::MongoMapper::StaleRecordsCleanerMixin
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/orm/mongoid4.rb
+++ b/lib/doorkeeper/orm/mongoid4.rb
@@ -8,6 +8,7 @@ module Doorkeeper
           require 'doorkeeper/orm/mongoid4/access_grant'
           require 'doorkeeper/orm/mongoid4/access_token'
           require 'doorkeeper/orm/mongoid4/application'
+          require 'doorkeeper/orm/mongoid4/stale_records_cleaner'
         end
       end
 

--- a/lib/doorkeeper/orm/mongoid4/stale_records_cleaner.rb
+++ b/lib/doorkeeper/orm/mongoid4/stale_records_cleaner.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module Orm
+    module Mongoid4
+      class StaleRecordsCleaner
+        include DoorkeeperMongodb::Mixins::Mongoid::StaleRecordsCleanerMixin
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/orm/mongoid5.rb
+++ b/lib/doorkeeper/orm/mongoid5.rb
@@ -8,6 +8,7 @@ module Doorkeeper
           require 'doorkeeper/orm/mongoid5/access_grant'
           require 'doorkeeper/orm/mongoid5/access_token'
           require 'doorkeeper/orm/mongoid5/application'
+          require 'doorkeeper/orm/mongoid5/stale_records_cleaner'
         end
       end
 

--- a/lib/doorkeeper/orm/mongoid5/stale_records_cleaner.rb
+++ b/lib/doorkeeper/orm/mongoid5/stale_records_cleaner.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module Orm
+    module Mongoid5
+      class StaleRecordsCleaner
+        include DoorkeeperMongodb::Mixins::Mongoid::StaleRecordsCleanerMixin
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/orm/mongoid6.rb
+++ b/lib/doorkeeper/orm/mongoid6.rb
@@ -8,6 +8,7 @@ module Doorkeeper
           require 'doorkeeper/orm/mongoid6/access_grant'
           require 'doorkeeper/orm/mongoid6/access_token'
           require 'doorkeeper/orm/mongoid6/application'
+          require 'doorkeeper/orm/mongoid6/stale_records_cleaner'
         end
       end
 

--- a/lib/doorkeeper/orm/mongoid6/stale_records_cleaner.rb
+++ b/lib/doorkeeper/orm/mongoid6/stale_records_cleaner.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module Orm
+    module Mongoid6
+      class StaleRecordsCleaner
+        include DoorkeeperMongodb::Mixins::Mongoid::StaleRecordsCleanerMixin
+      end
+    end
+  end
+end

--- a/lib/doorkeeper/orm/mongoid7.rb
+++ b/lib/doorkeeper/orm/mongoid7.rb
@@ -8,6 +8,7 @@ module Doorkeeper
           require 'doorkeeper/orm/mongoid7/access_grant'
           require 'doorkeeper/orm/mongoid7/access_token'
           require 'doorkeeper/orm/mongoid7/application'
+          require 'doorkeeper/orm/mongoid7/stale_records_cleaner'
         end
       end
 

--- a/lib/doorkeeper/orm/mongoid7/stale_records_cleaner.rb
+++ b/lib/doorkeeper/orm/mongoid7/stale_records_cleaner.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Doorkeeper
+  module Orm
+    module Mongoid7
+      class StaleRecordsCleaner
+        include DoorkeeperMongodb::Mixins::Mongoid::StaleRecordsCleanerMixin
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Doorkeeper 5.0 had several changes, including PKCE support which are required for the ORM to work properly.

I did a diff of doorkeeper 4.2.6 and 5.0 to determine what changes we would need:
https://github.com/doorkeeper-gem/doorkeeper/compare/v4.2.6...master?expand=1

I concentrated on the mixin changes which represent the major changes that this gem should be concerned with.

I considered using the Doorkeeper mixins now that they do not include ActiveRecord, but felt that it was best to do that at a later time.

### Other Information

I was able to get the master branch of doorkeeper tests to run locally, but do not know how to get CI tests to work.

Thanks for contributing to Doorkeeper-MongoDB project!