### PR TITLE
Adding method called plaintext secret that returns the secret because

### DIFF
--- a/lib/doorkeeper/orm/mongoid7/application.rb
+++ b/lib/doorkeeper/orm/mongoid7/application.rb
@@ -20,6 +20,10 @@ module Doorkeeper
 
     has_many :authorized_tokens, class_name: 'Doorkeeper::AccessToken'
 
+    def plaintext_secret
+      self.secret
+    end
+    
     def self.authorized_for(resource_owner)
       ids = AccessToken.where(
         resource_owner_id: resource_owner.id,


### PR DESCRIPTION
the application would throw an error when you created a new oauth
application.

Maybe there is a better solution.  adding this method seems to work well.