### PR TITLE
Unknown validator: 'RedirectUriValidator' (ArgumentError) after Rails 6 / Mongoid 7 upgrade

### DIFF
--- a/lib/doorkeeper-mongodb/mixins/mongoid/application_mixin.rb
+++ b/lib/doorkeeper-mongodb/mixins/mongoid/application_mixin.rb
@@ -23,7 +23,7 @@ module DoorkeeperMongodb
 
           validates :name, :secret, :uid, presence: true
           validates :uid, uniqueness: true
-          #validates :redirect_uri, redirect_uri: true
+          validates :redirect_uri, "doorkeeper/redirect_uri": true
           validates :confidential, inclusion: { in: [true, false] }
 
           validate :scopes_match_configured, if: :enforce_scopes?

--- a/lib/doorkeeper-mongodb/mixins/mongoid/application_mixin.rb
+++ b/lib/doorkeeper-mongodb/mixins/mongoid/application_mixin.rb
@@ -23,7 +23,7 @@ module DoorkeeperMongodb
 
           validates :name, :secret, :uid, presence: true
           validates :uid, uniqueness: true
-          validates :redirect_uri, redirect_uri: true
+          #validates :redirect_uri, redirect_uri: true
           validates :confidential, inclusion: { in: [true, false] }
 
           validate :scopes_match_configured, if: :enforce_scopes?

--- a/lib/doorkeeper-mongodb/redirect_uri_validator_monkey_path.rb
+++ b/lib/doorkeeper-mongodb/redirect_uri_validator_monkey_path.rb
@@ -1,0 +1,2 @@
+require 'doorkeeper/orm/active_record/redirect_uri_validator'
+class RedirectUriValidator < Doorkeeper::RedirectUriValidator; end

--- a/lib/doorkeeper-mongodb/redirect_uri_validator_monkey_path.rb
+++ b/lib/doorkeeper-mongodb/redirect_uri_validator_monkey_path.rb
@@ -1,2 +1,0 @@
-require 'doorkeeper/orm/active_record/redirect_uri_validator'
-class RedirectUriValidator < Doorkeeper::RedirectUriValidator; end


### PR DESCRIPTION
### Summary
After upgrading to Rails 6
https://github.com/doorkeeper-gem/doorkeeper-mongodb/issues/39
