### PR TITLE
Revoke old_refresh_token if previous_refresh_token is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ User-visible changes worth mentioning.
 
 ## master
 
-- [#] Your description here
+- [#62] Revoke `old_refresh_token` if `previous_refresh_token` is present.
 
 ## 5.2.1
 

--- a/lib/doorkeeper-mongodb/mixins/mongoid/access_token_mixin.rb
+++ b/lib/doorkeeper-mongodb/mixins/mongoid/access_token_mixin.rb
@@ -368,10 +368,10 @@ module DoorkeeperMongodb
         # and clears `:previous_refresh_token` attribute.
         #
         def revoke_previous_refresh_token!
-          return unless self.class.refresh_token_revoked_on_use?
+          return if !self.class.refresh_token_revoked_on_use? || previous_refresh_token.blank?
 
           old_refresh_token&.revoke
-          update(previous_refresh_token: "")
+          update_attribute(:previous_refresh_token, "")
         end
 
         private


### PR DESCRIPTION
This is the exact same PR as was made here: https://github.com/doorkeeper-gem/doorkeeper/pull/1496 which fixes https://github.com/doorkeeper-gem/doorkeeper-mongodb/issues/61