### PR TITLE
Use run_hooks instead of initialize_models! / initialize_application_owner!

### DIFF
--- a/lib/doorkeeper/orm/mongoid4.rb
+++ b/lib/doorkeeper/orm/mongoid4.rb
@@ -5,7 +5,21 @@ require "active_support/lazy_load_hooks"
 module Doorkeeper
   module Orm
     module Mongoid4
+      def self.run_hooks
+        lazy_load do
+          require "doorkeeper/orm/mongoid4/access_grant"
+          require "doorkeeper/orm/mongoid4/access_token"
+          require "doorkeeper/orm/mongoid4/application"
+          require "doorkeeper/orm/mongoid4/stale_records_cleaner"
+          require "doorkeeper/orm/concerns/mongoid/ownership"
+          Doorkeeper::Application.include Doorkeeper::Orm::Concerns::Mongoid::Ownership
+        end
+        @initialized_hooks = true
+      end
+
+      # @deprecated
       def self.initialize_models!
+        return if @initialized_hooks
         lazy_load do
           require "doorkeeper/orm/mongoid4/access_grant"
           require "doorkeeper/orm/mongoid4/access_token"
@@ -14,7 +28,9 @@ module Doorkeeper
         end
       end
 
+      # @deprecated
       def self.initialize_application_owner!
+        return if @initialized_hooks
         lazy_load do
           require "doorkeeper/orm/concerns/mongoid/ownership"
 

--- a/lib/doorkeeper/orm/mongoid5.rb
+++ b/lib/doorkeeper/orm/mongoid5.rb
@@ -5,7 +5,21 @@ require "active_support/lazy_load_hooks"
 module Doorkeeper
   module Orm
     module Mongoid5
+      def self.run_hooks
+        lazy_load do
+          require "doorkeeper/orm/mongoid5/access_grant"
+          require "doorkeeper/orm/mongoid5/access_token"
+          require "doorkeeper/orm/mongoid5/application"
+          require "doorkeeper/orm/mongoid5/stale_records_cleaner"
+          require "doorkeeper/orm/concerns/mongoid/ownership"
+          Doorkeeper::Application.include Doorkeeper::Orm::Concerns::Mongoid::Ownership
+        end
+        @initialized_hooks = true
+      end
+
+      # @deprecated
       def self.initialize_models!
+        return if @initialized_hooks
         lazy_load do
           require "doorkeeper/orm/mongoid5/access_grant"
           require "doorkeeper/orm/mongoid5/access_token"
@@ -14,7 +28,9 @@ module Doorkeeper
         end
       end
 
+      # @deprecated
       def self.initialize_application_owner!
+        return if @initialized_hooks
         lazy_load do
           require "doorkeeper/orm/concerns/mongoid/ownership"
 

--- a/lib/doorkeeper/orm/mongoid6.rb
+++ b/lib/doorkeeper/orm/mongoid6.rb
@@ -5,7 +5,21 @@ require "active_support/lazy_load_hooks"
 module Doorkeeper
   module Orm
     module Mongoid6
+      def self.run_hooks
+        lazy_load do
+          require "doorkeeper/orm/mongoid6/access_grant"
+          require "doorkeeper/orm/mongoid6/access_token"
+          require "doorkeeper/orm/mongoid6/application"
+          require "doorkeeper/orm/mongoid6/stale_records_cleaner"
+          require "doorkeeper/orm/concerns/mongoid/ownership"
+          Doorkeeper::Application.include Doorkeeper::Orm::Concerns::Mongoid::Ownership
+        end
+        @initialized_hooks = true
+      end
+
+      # @deprecated
       def self.initialize_models!
+        return if @initialized_hooks
         lazy_load do
           require "doorkeeper/orm/mongoid6/access_grant"
           require "doorkeeper/orm/mongoid6/access_token"
@@ -14,7 +28,9 @@ module Doorkeeper
         end
       end
 
+      # @deprecated
       def self.initialize_application_owner!
+        return if @initialized_hooks
         lazy_load do
           require "doorkeeper/orm/concerns/mongoid/ownership"
 

--- a/lib/doorkeeper/orm/mongoid7.rb
+++ b/lib/doorkeeper/orm/mongoid7.rb
@@ -5,7 +5,21 @@ require "active_support/lazy_load_hooks"
 module Doorkeeper
   module Orm
     module Mongoid7
+      def self.run_hooks
+        lazy_load do
+          require "doorkeeper/orm/mongoid7/access_grant"
+          require "doorkeeper/orm/mongoid7/access_token"
+          require "doorkeeper/orm/mongoid7/application"
+          require "doorkeeper/orm/mongoid7/stale_records_cleaner"
+          require "doorkeeper/orm/concerns/mongoid/ownership"
+          Doorkeeper::Application.include Doorkeeper::Orm::Concerns::Mongoid::Ownership
+        end
+        @initialized_hooks = true
+      end
+
+      # @deprecated
       def self.initialize_models!
+        return if @initialized_hooks
         lazy_load do
           require "doorkeeper/orm/mongoid7/access_grant"
           require "doorkeeper/orm/mongoid7/access_token"
@@ -14,7 +28,9 @@ module Doorkeeper
         end
       end
 
+      # @deprecated
       def self.initialize_application_owner!
+        return if @initialized_hooks
         lazy_load do
           require "doorkeeper/orm/concerns/mongoid/ownership"
 


### PR DESCRIPTION
Fixes #60

Fixes deprecation warning coming from doorkeeper in core library in a backward compatible manner.


