### PR TITLE
Fix Github actions + drop Mongoid 4/5 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,82 +4,76 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: >-
-      ${{ matrix.ruby }}
+    name: ${{ matrix.ruby }}
     env:
       CI: true
       TESTOPTS: -v
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        experimental: [false]
         include:
-          # mongoid4 requires activemodel ~> 4.0
-          - orm: 'mongoid4'
-            ruby: '2.2'
-            rails: '4.2'
-
-          # mongoid5 requires activemodel ~> 4.0
-          - orm: 'mongoid5'
-            ruby: '2.2'
-            rails: '4.2'
-
           # mongoid6 requires activemodel >= 5.1, < 6.0
           - orm: 'mongoid6'
             ruby: '2.5'
             rails: '5.1'
-          - orm: 'mongoid6'
-            ruby: '2.5'
-            rails: '6.0'
+            experimental: false
 
           # mongoid7 requires activemodel >= 5.1, < 8.0
           - orm: 'mongoid7'
             ruby: '2.5'
             rails: '5.1'
+            experimental: false
           - orm: 'mongoid7'
             ruby: '2.5'
             rails: '5.2'
+            experimental: false
           - orm: 'mongoid7'
             ruby: '2.6'
             rails: '6.0'
+            experimental: false
           - orm: 'mongoid7'
             ruby: '2.7'
             rails: '6.0'
+            experimental: false
           - orm: 'mongoid7'
             ruby: '3.0'
             rails: '6.1'
+            experimental: false
           - orm: 'mongoid7'
             ruby: '3.0'
             rails: '7.0'
+            experimental: false
           - orm: 'mongoid7'
             ruby: '3.1'
             rails: '7.0'
+            experimental: false
 
           # jruby
           - orm: 'mongoid7'
             ruby: 'jruby'
             rails: '6.1'
+            experimental: false
 
           # truffleruby
           - orm: 'mongoid7'
             ruby: 'truffleruby'
             rails: '6.1'
+            experimental: false
 
           # experimental
           - orm: 'mongoid7'
             ruby: 'head'
             rails: '7.0'
-            experimental: 'true'
+            experimental: true
           - orm: 'mongoid7'
             ruby: 'jruby-head'
             rails: '7.0'
-            experimental: 'true'
+            experimental: true
           - orm: 'mongoid7'
             ruby: 'truffleruby-head'
             rails: '7.0'
-            experimental: 'true'
+            experimental: true
 
     steps:
       - name: repo checkout
@@ -100,11 +94,13 @@ jobs:
       - name: bundle install
         run:  bundle install --jobs 4 --retry 3
         env:
-          BUNDLE_GEMFILE: "Gemfile.${{matrix.orm}}.rb"
+          RAILS: ${{ matrix.rails }}
+          BUNDLE_GEMFILE: 'gemfiles/Gemfile.${{matrix.orm}}.rb'
 
       - name: test
         timeout-minutes: 10
         run: bundle exec rake spec
         continue-on-error: ${{ matrix.experimental }}
         env:
-          BUNDLE_GEMFILE: "Gemfile.${{matrix.orm}}.rb"
+          RAILS: ${{ matrix.rails }}
+          BUNDLE_GEMFILE: 'gemfiles/Gemfile.${{matrix.orm}}.rb'

--- a/README.md
+++ b/README.md
@@ -10,27 +10,14 @@ of doorkeeper-mongodb you are using in: https://github.com/doorkeeper-gem/doorke
 ## Installation
 
 `doorkeeper-mongodb` provides [Doorkeeper](https://github.com/doorkeeper-gem/doorkeeper) support
-for [Mongoid](https://github.com/mongodb/mongoid) versions 4, 5, 6 and 7. Earlier versions of Mongoid are supported
-on `doorkeeper-mongodb` version 3.0.
+for [Mongoid](https://github.com/mongodb/mongoid) versions 6 and later. Earlier versions of Mongoid
+are supported on earlier versions of `doorkeeper-mongodb`.
 
-To start using it, add to your Gemfile:
+To start using it, add both `doorkeeper` and `doorkeeper-mongodb` to your Gemfile:
 
-``` ruby
-# For Doorkeeper >= 5.2
-gem 'doorkeeper', '~> 5.2'
-gem 'doorkeeper-mongodb', '~> 5.2'
-
-# For Doorkeeper >= 5.0
-gem 'doorkeeper', '~> 5.0'
-gem 'doorkeeper-mongodb', '~> 5.0'
-
-# For Doorkeeper >= 4.4 && < 5.0
-gem 'doorkeeper', '~> 4.4'
-gem 'doorkeeper-mongodb', '~> 4.2'
-
-# For Doorkeeper < 4.4
-gem 'doorkeeper', '~> 4.3'
-gem 'doorkeeper-mongodb', '~> 4.1.0'
+```ruby
+gem 'doorkeeper'
+gem 'doorkeeper-mongodb'
 
 # or if you want to use cutting edge version:
 # gem 'doorkeeper-mongodb', github: 'doorkeeper-gem/doorkeeper-mongodb'
@@ -38,7 +25,9 @@ gem 'doorkeeper-mongodb', '~> 4.1.0'
 
 Run [doorkeeper’s installation generator]:
 
-    rails generate doorkeeper:install
+```bash
+$ rails generate doorkeeper:install
+```
 
 [doorkeeper’s installation generator]: https://github.com/doorkeeper-gem/doorkeeper#installation
 
@@ -47,7 +36,7 @@ This will install the doorkeeper initializer into
 
 Set the ORM configuration:
 
-``` ruby
+```ruby
 Doorkeeper.configure do
   orm :mongoid7 # or any other version of mongoid
 end
@@ -67,7 +56,7 @@ variables defined in `.travis.yml` file.
 
 To run locally, you need to choose a gemfile, with a command similar to:
 
-```
+```bash
 $ export RAILS=5.1
 $ export BUNDLE_GEMFILE=$PWD/gemfiles/Gemfile.mongoid6.rb
 ```

--- a/doorkeeper-mongodb.gemspec
+++ b/doorkeeper-mongodb.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "doorkeeper", ">= 5.2", "< 6.0"
 
-  gem.add_development_dependency "capybara", "~> 2.17"
   gem.add_development_dependency "coveralls"
   gem.add_development_dependency "database_cleaner", "~> 1.6.0"
   gem.add_development_dependency "factory_bot", "~> 4.8"

--- a/gemfiles/Gemfile.common.rb
+++ b/gemfiles/Gemfile.common.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-ENV["RAILS"] ||= "5.0"
-ENV["DOORKEEPER"] ||= "5.0"
+ENV['RAILS'] ||= '5'
+ENV['DOORKEEPER'] ||= '5'
 
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-gemspec path: "../"
+gemspec path: '../'
 
-gem "rails", "~> #{ENV["RAILS"]}"
-gem "doorkeeper", "~> #{ENV["DOORKEEPER"]}"
-gem "bcrypt"
+gem 'rails', "~> #{ENV['RAILS']}"
+gem 'doorkeeper', "~> #{ENV['DOORKEEPER']}"
+gem 'bcrypt'
 
-gem "rspec-core"
-gem "rspec-expectations"
-gem "rspec-mocks"
-gem "rspec-rails", "~> 4.0.0"
-gem "rspec-support"
+gem 'rspec-core'
+gem 'rspec-expectations'
+gem 'rspec-mocks'
+gem 'rspec-rails', '~> 4.0.0'
+gem 'rspec-support'

--- a/gemfiles/Gemfile.mongoid4.rb
+++ b/gemfiles/Gemfile.mongoid4.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-gemfile = File.expand_path("Gemfile.common.rb", __dir__)
-instance_eval IO.read(gemfile), gemfile
-
-gem "mongoid", "~> 4"

--- a/gemfiles/Gemfile.mongoid5.rb
+++ b/gemfiles/Gemfile.mongoid5.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-gemfile = File.expand_path("Gemfile.common.rb", __dir__)
-instance_eval IO.read(gemfile), gemfile
-
-gem "mongoid", "~> 5"

--- a/gemfiles/Gemfile.mongoid6.rb
+++ b/gemfiles/Gemfile.mongoid6.rb
@@ -3,4 +3,4 @@
 gemfile = File.expand_path("Gemfile.common.rb", __dir__)
 instance_eval IO.read(gemfile), gemfile
 
-gem "mongoid", "~> 6"
+gem "mongoid", "~> 6.0"


### PR DESCRIPTION
GH actions `test.yml` from previous PR didn't work.

In addition, I've dropped support for Mongoid 4/5. They are deep EOL anyway, and it's too much hassle to get them to work with Github actions (e.g. bundler fails due to version error.) Technically they still work with the gem.

JRuby / TruffleRuby tests added too!

Rubocop will be fixed in a separate PR: https://github.com/doorkeeper-gem/doorkeeper-mongodb/pull/79 