### PR TITLE
Add required `inverse_of` option on Doorkeeper::Application

### DIFF
--- a/lib/doorkeeper-mongodb/mixins/mongoid/application_mixin.rb
+++ b/lib/doorkeeper-mongodb/mixins/mongoid/application_mixin.rb
@@ -14,7 +14,7 @@ module DoorkeeperMongodb
         included do
           has_many_options = {
             dependent: :delete,
-
+            inverse_of: :application
           }
 
           # Mongoid7 dropped :delete option


### PR DESCRIPTION
### Summary

Without this option, calling `access_tokens` or `access_grants` will not work on Doorkeeper::Application.